### PR TITLE
Fix refresh_token check

### DIFF
--- a/src/Dropbox.php
+++ b/src/Dropbox.php
@@ -5,6 +5,7 @@ namespace Dcblogdev\Dropbox;
 use Dcblogdev\Dropbox\Facades\Dropbox as Api;
 use Dcblogdev\Dropbox\Models\DropboxToken;
 use Dcblogdev\Dropbox\Resources\Files;
+use Illuminate\Support\Carbon;
 
 use GuzzleHttp\Client;
 use Exception;
@@ -171,8 +172,7 @@ class Dropbox
         if (isset($token->refresh_token)) {
             // Check if token is expired
             // Get current time + 5 minutes (to allow for time differences)
-            $now = time() + 300;
-            if ($token->expires_in <= $now) {
+            if (Carbon::parse($token->expires_in)->isPast()) {
                 // Token is expired (or very close to it) so let's refresh
                 $params = [
                     'grant_type'    => 'refresh_token',


### PR DESCRIPTION
Fix the refresh token check with help of carbon package.

The $now = time() + 300 results in an integer, while the $token->expires_in is a datetime string.
This check will therefor always fail.

With this change it will just look at the expires_in date and checks if it is in the past or not.